### PR TITLE
With-files-write macro

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -168,4 +168,5 @@
 
     ;; version calls
     :version
-    :version-deps))
+   :version-deps
+   #:with-files-write))


### PR DESCRIPTION
Hi Jaidyn,

I've implemented a convenience macro for files-write. For now, I have put it into the main file. Are you OK with add-ons going in the main file or should they go in another file or package? I'm a bit worried about cluttering up the api interface.

There are also a couple of bug fixes included, one of which seems to be the result of IPFS daemon version changes. I'm running 0.8.0 currently. Hopefully I didn't damage anything for other versions.

All the best,
Ben